### PR TITLE
Actions are exported as an object to avoid bug from compilation

### DIFF
--- a/src/app/store/actions.js
+++ b/src/app/store/actions.js
@@ -1,5 +1,8 @@
 import * as types from './mutations'
 
-export const myAction = ({ commit }) => {
-  commit(types.MUTATION_NAME)
+const actions = {
+  myAction: ({ commit }) => {
+    commit(types.MUTATION_NAME)
+  }
 }
+export default actions

--- a/src/app/store/index.js
+++ b/src/app/store/index.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
-import * as actions from './actions'
+import actions from './actions'
 // import * as getters from './getters'
 import overview from './modules/overview'
 import error from './modules/error'


### PR DESCRIPTION
Before this change, when I launched the boilerplate with 'npm run dev' I had a blank page with  the following error: 

vuex.esm.js:97 Uncaught Error: [vuex] actions should be function or object with "handler" function but "actions.__esModule" is true.
    at assert (vuex.esm.js:97)
    at vuex.esm.js:271
    at vuex.esm.js:85
    at Array.forEach (<anonymous>)
    at forEachValue (vuex.esm.js:85)
    at vuex.esm.js:270
    at Array.forEach (<anonymous>)
    at assertRawModule (vuex.esm.js:265)
    at ModuleCollection.register (vuex.esm.js:191)
    at new ModuleCollection (vuex.esm.js:165)


This fix it.
